### PR TITLE
New attribute to allow one property to define a dependency on a value of another

### DIFF
--- a/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityAttribute.cs
+++ b/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityAttribute.cs
@@ -6,7 +6,7 @@ namespace Octopus.Data.Resources.Attributes
     /// Use this attribute to specify whether a given property is applicable based on the value of another property
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
-    public class PropertyApplicabilityAttribute : Attribute
+    public abstract class PropertyApplicabilityAttribute : Attribute
     {
         internal PropertyApplicabilityAttribute(PropertyApplicabilityMode mode, string propertyName, object propertyValue)
         {

--- a/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityAttribute.cs
+++ b/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityAttribute.cs
@@ -8,48 +8,45 @@ namespace Octopus.Data.Resources.Attributes
     [AttributeUsage(AttributeTargets.Property)]
     public abstract class PropertyApplicabilityAttribute : Attribute
     {
-        internal PropertyApplicabilityAttribute(PropertyApplicabilityMode mode, string propertyName, object propertyValue)
+        internal PropertyApplicabilityAttribute(PropertyApplicabilityMode mode, string dependsOnPropertyName, object dependsOnPropertyValue)
         {
             Mode = mode;
-            PropertyName = propertyName;
-            PropertyValue = propertyValue;
+            DependsOnPropertyName = dependsOnPropertyName;
+            DependsOnPropertyValue = dependsOnPropertyValue;
         }
         
         public PropertyApplicabilityMode Mode { get; }
         
-        /// <summary>
-        /// The name of the property that the property the attribute has been applied to depends on
-        /// </summary>
-        public string PropertyName { get; }
+        public string DependsOnPropertyName { get; }
         
-        public object PropertyValue { get; }
+        public object DependsOnPropertyValue { get; }
     }
 
     public class ApplicableWhenAnyValueAttribute : PropertyApplicabilityAttribute
     {
-        public ApplicableWhenAnyValueAttribute(string propertyName) : 
-            base(PropertyApplicabilityMode.ApplicableIfHasAnyValue, propertyName, null)
+        public ApplicableWhenAnyValueAttribute(string dependsOnPropertyName) : 
+            base(PropertyApplicabilityMode.ApplicableIfHasAnyValue, dependsOnPropertyName, null)
         {}
     }
 
     public class ApplicableWhenNoValueAttribute : PropertyApplicabilityAttribute
     {
-        public ApplicableWhenNoValueAttribute(string propertyName) : 
-            base(PropertyApplicabilityMode.ApplicableIfHasNoValue, propertyName, null)
+        public ApplicableWhenNoValueAttribute(string dependsOnPropertyName) : 
+            base(PropertyApplicabilityMode.ApplicableIfHasNoValue, dependsOnPropertyName, null)
         {}
     }
 
     public class ApplicableWhenSpecificValueAttribute : PropertyApplicabilityAttribute
     {
-        public ApplicableWhenSpecificValueAttribute(string propertyName, object propertyValue) : 
-            base(PropertyApplicabilityMode.ApplicableIfSpecificValue, propertyName, propertyValue)
+        public ApplicableWhenSpecificValueAttribute(string dependsOnPropertyName, object dependsOnPropertyValue) : 
+            base(PropertyApplicabilityMode.ApplicableIfSpecificValue, dependsOnPropertyName, dependsOnPropertyValue)
         {}
     }
 
     public class ApplicableWhenNotSpecificValueAttribute : PropertyApplicabilityAttribute
     {
-        public ApplicableWhenNotSpecificValueAttribute(string propertyName, object propertyValue) : 
-            base(PropertyApplicabilityMode.ApplicableIfNotSpecificValue, propertyName, propertyValue)
+        public ApplicableWhenNotSpecificValueAttribute(string dependsOnPropertyName, object dependsOnPropertyValue) : 
+            base(PropertyApplicabilityMode.ApplicableIfNotSpecificValue, dependsOnPropertyName, dependsOnPropertyValue)
         {}
     }
 }

--- a/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityAttribute.cs
+++ b/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityAttribute.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace Octopus.Data.Resources.Attributes
+{
+    /// <summary>
+    /// Use this attribute to specify whether a given property is applicable based on the value of another property
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class PropertyApplicabilityAttribute : Attribute
+    {
+        internal PropertyApplicabilityAttribute(PropertyApplicabilityMode mode, string propertyName, object propertyValue)
+        {
+            Mode = mode;
+            PropertyName = propertyName;
+            PropertyValue = propertyValue;
+        }
+        
+        public PropertyApplicabilityMode Mode { get; }
+        
+        /// <summary>
+        /// The name of the property that the property the attribute has been applied to depends on
+        /// </summary>
+        public string PropertyName { get; }
+        
+        public object PropertyValue { get; }
+    }
+
+    public class ApplicableWhenAnyValueAttribute : PropertyApplicabilityAttribute
+    {
+        public ApplicableWhenAnyValueAttribute(string propertyName) : 
+            base(PropertyApplicabilityMode.ApplicableIfHasAnyValue, propertyName, null)
+        {}
+    }
+
+    public class ApplicableWhenNoValueAttribute : PropertyApplicabilityAttribute
+    {
+        public ApplicableWhenNoValueAttribute(string propertyName) : 
+            base(PropertyApplicabilityMode.ApplicableIfHasNoValue, propertyName, null)
+        {}
+    }
+
+    public class ApplicableWhenSpecificValueAttribute : PropertyApplicabilityAttribute
+    {
+        public ApplicableWhenSpecificValueAttribute(string propertyName, object propertyValue) : 
+            base(PropertyApplicabilityMode.ApplicableIfSpecificValue, propertyName, propertyValue)
+        {}
+    }
+
+    public class ApplicableWhenNotSpecificValueAttribute : PropertyApplicabilityAttribute
+    {
+        public ApplicableWhenNotSpecificValueAttribute(string propertyName, object propertyValue) : 
+            base(PropertyApplicabilityMode.ApplicableIfNotSpecificValue, propertyName, propertyValue)
+        {}
+    }
+}

--- a/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityMode.cs
+++ b/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityMode.cs
@@ -1,0 +1,9 @@
+namespace Octopus.Data.Resources.Attributes
+{
+    public enum PropertyApplicabilityMode {
+        ApplicableIfHasAnyValue,
+        ApplicableIfHasNoValue,
+        ApplicableIfSpecificValue,
+        ApplicableIfNotSpecificValue
+    }
+}


### PR DESCRIPTION
This is being driven by things like the Jira Issue Tracker, where some settings are only relevant under some circumstances. E.g. you Connect App password only matters if using Jira Cloud and not Jira Server.

Relates to OctopusDeploy/JiraIssueTracker#6