### PR TITLE
Moving the EncryptedAttribute from Octopus.Shared

### DIFF
--- a/source/Octopus.Data/Model/EncryptedAttribute.cs
+++ b/source/Octopus.Data/Model/EncryptedAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Octopus.Data.Model
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class EncryptedAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
So extensions can see/use this attribute