### PR TITLE
Fix Identity Equals operator

### DIFF
--- a/source/Octopus.Data/Model/User/Identity.cs
+++ b/source/Octopus.Data/Model/User/Identity.cs
@@ -70,10 +70,16 @@ namespace Octopus.Data.Model.User
             if (ReferenceEquals(this, other)) return true;
             if (IdentityProviderName != other.IdentityProviderName) return false;
             return Claims.All(kvp =>
-                !kvp.Value.IsIdentifyingClaim ||
-                (other.Claims.ContainsKey(kvp.Key) && (
-                     (string.IsNullOrWhiteSpace(kvp.Value.Value) && string.IsNullOrWhiteSpace(other.Claims[kvp.Key].Value)) ||
-                     kvp.Value.Value.Equals(other.Claims[kvp.Key].Value, StringComparison.OrdinalIgnoreCase))));
+            {
+                if (!kvp.Value.IsIdentifyingClaim)
+                    return true;
+                if (!other.Claims.ContainsKey(kvp.Key))
+                    return false;
+                var existingClaimValue = kvp.Value.Value;
+                var bothClaimsAreNullOrWhitespace = string.IsNullOrWhiteSpace(existingClaimValue) && string.IsNullOrWhiteSpace(other.Claims[kvp.Key].Value);
+                var existingClaimHasValueAndMatches = !string.IsNullOrWhiteSpace(existingClaimValue) && existingClaimValue.Equals(other.Claims[kvp.Key].Value, StringComparison.OrdinalIgnoreCase);
+                return bothClaimsAreNullOrWhitespace || existingClaimHasValueAndMatches;
+            });
         }
 
         public bool Equals(IdentityResource other)
@@ -81,11 +87,16 @@ namespace Octopus.Data.Model.User
             if (ReferenceEquals(null, other)) return false;
             if (IdentityProviderName != other.IdentityProviderName) return false;
             return Claims.All(kvp =>
-                !kvp.Value.IsIdentifyingClaim ||
-                kvp.Value.IsServerSideOnly ||
-                (other.Claims.ContainsKey(kvp.Key) && (
-                     (string.IsNullOrWhiteSpace(kvp.Value.Value) && string.IsNullOrWhiteSpace(other.Claims[kvp.Key].Value)) ||
-                     kvp.Value.Value.Equals(other.Claims[kvp.Key].Value, StringComparison.OrdinalIgnoreCase))));
+            {
+                if (!kvp.Value.IsIdentifyingClaim || kvp.Value.IsServerSideOnly)
+                    return true;
+                if (!other.Claims.ContainsKey(kvp.Key))
+                    return false;
+                var existingClaimValue = kvp.Value.Value;
+                var bothClaimsAreNullOrWhitespace = string.IsNullOrWhiteSpace(existingClaimValue) && string.IsNullOrWhiteSpace(other.Claims[kvp.Key].Value);
+                var existingClaimHasValueAndMatches = !string.IsNullOrWhiteSpace(existingClaimValue) && existingClaimValue.Equals(other.Claims[kvp.Key].Value, StringComparison.OrdinalIgnoreCase);
+                return bothClaimsAreNullOrWhitespace || existingClaimHasValueAndMatches;
+            });
         }
 
         public override bool Equals(object obj)

--- a/source/Octopus.Data/Octopus.Data.csproj
+++ b/source/Octopus.Data/Octopus.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.0.0</VersionPrefix>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Octopus.Data</AssemblyName>
     <PackageId>Octopus.Data</PackageId>
     <Authors>Octopus Deploy</Authors>

--- a/source/Octopus.Data/Octopus.Data.csproj
+++ b/source/Octopus.Data/Octopus.Data.csproj
@@ -9,7 +9,6 @@
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Data</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/OctopusDeploy/Data/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/source/OctopusData.sln
+++ b/source/OctopusData.sln
@@ -6,6 +6,8 @@ VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octopus.Data", "Octopus.Data\Octopus.Data.csproj", "{B0944CF9-6D8C-4B5E-9655-1433E47CAE83}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{54FABE66-B9C9-4A24-B42C-C8C5C35C27D1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -16,6 +18,10 @@ Global
 		{B0944CF9-6D8C-4B5E-9655-1433E47CAE83}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0944CF9-6D8C-4B5E-9655-1433E47CAE83}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B0944CF9-6D8C-4B5E-9655-1433E47CAE83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54FABE66-B9C9-4A24-B42C-C8C5C35C27D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54FABE66-B9C9-4A24-B42C-C8C5C35C27D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54FABE66-B9C9-4A24-B42C-C8C5C35C27D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54FABE66-B9C9-4A24-B42C-C8C5C35C27D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Tests/IdentityResourceTests.cs
+++ b/source/Tests/IdentityResourceTests.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using Octopus.Data.Model.User;
+using Octopus.Data.Resources.Users;
+
+namespace Tests
+{
+    public class IdentityResourceTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void EqualityCheckWhereIdentifyingAttributeHasChangedWorksWhenExistingIdentityHasIdentifyingTrue()
+        {
+            var identity1 = CreateIdentity("foo@test.com", true, "foo@test.com", "foo");
+            var identity2 = CreateIdentityResource("foo@test.com", false, "foo@test.com", "foo");
+            Assert.IsTrue(identity1.Equals(identity2));
+        }
+
+        [Test]
+        public void EqualityCheckWhereIdentifyingAttributeHasChangedWorksWhenExistingIdentityHasIdentifyingTrueAndNullValue()
+        {
+            var identity1 = CreateIdentity(null, true, "foo@test.com", "foo");
+            var identity2 = CreateIdentityResource("foo@test.com", false, "foo@test.com", "foo");
+            Assert.IsFalse(identity1.Equals(identity2));
+        }
+
+        [Test]
+        public void EqualityCheckWhereIdentifyingAttributeHasChangedWorksWhenOtherIdentityHasIdentifyingTrue()
+        {
+            var identity1 = CreateIdentity("foo@test.com", false, "foo@test.com", "foo");
+            var identity2 = CreateIdentityResource("foo@test.com", true, "foo@test.com", "foo");
+            Assert.IsTrue(identity1.Equals(identity2));
+        }
+
+        [Test]
+        public void EqualityCheckWhereIdentifyingAttributeHasChangedWorksWhenOtherIdentityHasIdentifyingTrueAndNullValue()
+        {
+            var identity1 = CreateIdentity("foo@test.com", false, "foo@test.com", "foo");
+            var identity2 = CreateIdentityResource(null, true, "foo@test.com", "foo");
+            Assert.IsTrue(identity1.Equals(identity2));
+        }
+
+        Identity CreateIdentity(string email, bool emailIsIdentifying, string upn, string displayName)
+        {
+            var identity = new Identity("Test Provider");
+            identity.Claims.Add("email", new IdentityClaim(email, emailIsIdentifying));
+            identity.Claims.Add("upn", new IdentityClaim(upn, true));
+            return identity;
+        }
+
+        IdentityResource CreateIdentityResource(string email, bool emailIsIdentifying, string upn, string displayName)
+        {
+            var identity = new IdentityResource("Test Provider");
+            identity.Claims.Add("email", new IdentityClaimResource(email, emailIsIdentifying));
+            identity.Claims.Add("upn", new IdentityClaimResource(upn, true));
+            return identity;
+        }
+    }
+}

--- a/source/Tests/IdentityTests.cs
+++ b/source/Tests/IdentityTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using Octopus.Data.Model.User;
+
+namespace Tests
+{
+    public class IdentityTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void EqualityCheckWhereIdentifyingAttributeHasChangedWorksWhenExistingIdentityHasIdentifyingTrue()
+        {
+            var identity1 = CreateIdentity("foo@test.com", true, "foo@test.com", "foo");
+            var identity2 = CreateIdentity("foo@test.com", false, "foo@test.com", "foo");
+            Assert.IsTrue(identity1.Equals(identity2));
+        }
+
+        [Test]
+        public void EqualityCheckWhereIdentifyingAttributeHasChangedWorksWhenExistingIdentityHasIdentifyingTrueAndNullValue()
+        {
+            var identity1 = CreateIdentity(null, true, "foo@test.com", "foo");
+            var identity2 = CreateIdentity("foo@test.com", false, "foo@test.com", "foo");
+            Assert.IsFalse(identity1.Equals(identity2));
+        }
+
+        [Test]
+        public void EqualityCheckWhereIdentifyingAttributeHasChangedWorksWhenOtherIdentityHasIdentifyingTrue()
+        {
+            var identity1 = CreateIdentity("foo@test.com", false, "foo@test.com", "foo");
+            var identity2 = CreateIdentity("foo@test.com", true, "foo@test.com", "foo");
+            Assert.IsTrue(identity1.Equals(identity2));
+        }
+
+        [Test]
+        public void EqualityCheckWhereIdentifyingAttributeHasChangedWorksWhenOtherIdentityHasIdentifyingTrueAndNullValue()
+        {
+            var identity1 = CreateIdentity("foo@test.com", false, "foo@test.com", "foo");
+            var identity2 = CreateIdentity(null, true, "foo@test.com", "foo");
+            Assert.IsTrue(identity1.Equals(identity2));
+        }
+
+        Identity CreateIdentity(string email, bool emailIsIdentifying, string upn, string displayName)
+        {
+            var identity = new Identity("Test Provider");
+            identity.Claims.Add("email", new IdentityClaim(email, emailIsIdentifying));
+            identity.Claims.Add("upn", new IdentityClaim(upn, true));
+            return identity;
+        }
+    }
+}

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="nunit" Version="3.11.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Octopus.Data\Octopus.Data.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixed a null reference issue caused when an identifying claim had a null value and then was compared against a new identity with a non-null value.

AD caused this for a couple of customers with the Email address.

Tests have been added around the data that caused the issue.

Relates to OctopusDeploy/Issues#5805