### PR TITLE
Added Experimental Attribute

### DIFF
--- a/source/Octopus.Data/Resources/Attributes/ExperimentalAttribute.cs
+++ b/source/Octopus.Data/Resources/Attributes/ExperimentalAttribute.cs
@@ -1,7 +1,13 @@
-﻿namespace Octopus.Data.Resources.Attributes
+﻿using System;
+
+namespace Octopus.Data.Resources.Attributes
 {
-    public class ExperimentalAttribute
+    /// <summary>
+    /// When applied to a Resource it won't generate APIs that use the Resource in the Swagger documentation generation
+    /// and it won't require the Resource to be apart of Octopus.Client 
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ExperimentalAttribute : Attribute
     {
-        
     }
 }

--- a/source/Octopus.Data/Resources/Attributes/ExperimentalAttribute.cs
+++ b/source/Octopus.Data/Resources/Attributes/ExperimentalAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace Octopus.Data.Resources.Attributes
+{
+    public class ExperimentalAttribute
+    {
+        
+    }
+}


### PR DESCRIPTION
This attribute stops the swagger documentation from being generated for any apis that map to it and won't require the resource to be apart of Octopus.Client. Doing this means the resource is experimental, should only be used internally and can be removed at any time.