### PR TITLE
Enabling Nullable Reference Types

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -51,6 +51,7 @@ Task("__Default")
     .IsDependentOn("__Clean")
     .IsDependentOn("__Restore")
     .IsDependentOn("__Build")
+    .IsDependentOn("__Test")
     .IsDependentOn("__Pack")
     .IsDependentOn("__CopyToLocalPackages");
 
@@ -85,6 +86,17 @@ Task("__Pack")
             ArgumentCustomization = args => args.Append($"/p:Version={nugetVersion}")
         });
 });
+
+Task("__Test")
+    .IsDependentOn("__Build")
+    .Does(() =>
+    {
+        DotNetCoreTest("source", new DotNetCoreTestSettings
+        {
+            Configuration = configuration,
+            NoBuild = true
+        });
+    });
 
 Task("__CopyToLocalPackages")
     .WithCriteria(BuildSystem.IsLocalBuild)

--- a/build.ps1
+++ b/build.ps1
@@ -80,8 +80,9 @@ function MD5HashFile([string] $filePath)
     }
 }
 
-Write-Host "Preparing to run build script..."
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
 
+Write-Host "Preparing to run build script..."
 if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }

--- a/source/Octopus.Data/Model/Configuration/ConfigurationDocument.cs
+++ b/source/Octopus.Data/Model/Configuration/ConfigurationDocument.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Octopus.Data.Model.Configuration
 {
     public abstract class ConfigurationDocument : IId

--- a/source/Octopus.Data/Model/Href.cs
+++ b/source/Octopus.Data/Model/Href.cs
@@ -4,7 +4,7 @@ namespace Octopus.Data.Model
 {
     public class Href : IEquatable<Href>
     {
-        private readonly string link;
+        readonly string link;
 
         public Href(string link)
         {
@@ -26,7 +26,7 @@ namespace Octopus.Data.Model
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
-            return Equals((Href) obj);
+            return Equals((Href)obj);
         }
 
         public override int GetHashCode()

--- a/source/Octopus.Data/Model/IDocument.cs
+++ b/source/Octopus.Data/Model/IDocument.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Octopus.Data.Model
 {
     public interface IDocument : IId, INamed

--- a/source/Octopus.Data/Model/IId.cs
+++ b/source/Octopus.Data/Model/IId.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Octopus.Data.Model
 {
     public interface IId

--- a/source/Octopus.Data/Model/INamed.cs
+++ b/source/Octopus.Data/Model/INamed.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Octopus.Data.Model
 {
     public interface INamed

--- a/source/Octopus.Data/Model/LinkCollectionExtensions.cs
+++ b/source/Octopus.Data/Model/LinkCollectionExtensions.cs
@@ -5,7 +5,10 @@ namespace Octopus.Data.Model
     public static class LinkCollectionExtensions
     {
         public static LinkCollection Pagination(this LinkCollection collection,
-            Func<int, int, string> formatWithSkipAndTake, int currentOffset, int perPage, int total)
+            Func<int, int, string> formatWithSkipAndTake,
+            int currentOffset,
+            int perPage,
+            int total)
         {
             collection.Add("Page.All", formatWithSkipAndTake(0, int.MaxValue));
             if (currentOffset > 0)
@@ -16,7 +19,7 @@ namespace Octopus.Data.Model
 
             collection.Add("Page.Current", formatWithSkipAndTake(currentOffset, perPage));
 
-            var lastPage = Math.Max(0, (int) Math.Ceiling((double) total / perPage) - 1);
+            var lastPage = Math.Max(0, (int)Math.Ceiling((double)total / perPage) - 1);
             collection.Add("Page.Last", formatWithSkipAndTake(lastPage * perPage, perPage));
 
             return collection;

--- a/source/Octopus.Data/Model/ReferenceCollection.cs
+++ b/source/Octopus.Data/Model/ReferenceCollection.cs
@@ -39,11 +39,11 @@ namespace Octopus.Data.Model
 
     public class ReferenceCollection<T> : HashSet<T>
     {
-        public ReferenceCollection(IEqualityComparer<T> comparer = null) : base(comparer)
+        public ReferenceCollection(IEqualityComparer<T>? comparer = null) : base(comparer)
         {
         }
 
-        public ReferenceCollection(IEnumerable<T> values, IEqualityComparer<T> comparer = null) : base(values, comparer)
+        public ReferenceCollection(IEnumerable<T> values, IEqualityComparer<T>? comparer = null) : base(values, comparer)
         {
         }
 
@@ -61,7 +61,7 @@ namespace Octopus.Data.Model
 
         public override string ToString()
         {
-            return string.Join(", ", this.Select(x => x.ToString()));
+            return string.Join(", ", this.Where(x => x != null).Select(x => x?.ToString()));
         }
     }
 }

--- a/source/Octopus.Data/Model/ReferenceCollection.cs
+++ b/source/Octopus.Data/Model/ReferenceCollection.cs
@@ -12,7 +12,7 @@ namespace Octopus.Data.Model
         }
 
         public ReferenceCollection(string singleValue)
-            : this(new[] {singleValue})
+            : this(new[] { singleValue })
         {
         }
 
@@ -33,7 +33,7 @@ namespace Octopus.Data.Model
 
         public static ReferenceCollection One(string item)
         {
-            return new ReferenceCollection {item};
+            return new ReferenceCollection { item };
         }
     }
 

--- a/source/Octopus.Data/Model/ReferenceCollection.cs
+++ b/source/Octopus.Data/Model/ReferenceCollection.cs
@@ -61,7 +61,7 @@ namespace Octopus.Data.Model
 
         public override string ToString()
         {
-            return string.Join(", ", this.Where(x => x != null).Select(x => x?.ToString()));
+            return string.Join(", ", this.Where(x => x != null).Select(x => x!.ToString()));
         }
     }
 }

--- a/source/Octopus.Data/Model/SensitiveString.cs
+++ b/source/Octopus.Data/Model/SensitiveString.cs
@@ -66,11 +66,9 @@ namespace Octopus.Data.Model
 
     public static class SensitiveStringExtensions
     {
-        public static SensitiveString? ToSensitiveString(this string s)
+        public static SensitiveString? ToSensitiveString(this string? s)
         {
-            if (s == null)
-                return null;
-            return new SensitiveString(s);
+            return s == null ? null : new SensitiveString(s);
         }
     }
 }

--- a/source/Octopus.Data/Model/SensitiveString.cs
+++ b/source/Octopus.Data/Model/SensitiveString.cs
@@ -4,9 +4,9 @@ using System.Diagnostics;
 namespace Octopus.Data.Model
 {
     [DebuggerDisplay("Sensitive: {Value}")]
-    public class SensitiveString : IEquatable<SensitiveString>, IEquatable<string>
+    public class SensitiveString
     {
-        public SensitiveString(string? value)
+        internal SensitiveString(string? value)
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value),
@@ -18,44 +18,26 @@ namespace Octopus.Data.Model
 
         public string Value { get; }
 
-        public bool Equals(SensitiveString other)
-        {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
-            return Value == other.Value;
-        }
-
-        public bool Equals(string other)
-        {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
-            return Value == other;
-        }
-
-        public override bool Equals(object? obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((SensitiveString) obj);
-        }
-
         public override int GetHashCode()
         {
             return (Value != null ? Value.GetHashCode() : 0);
         }
 
-        public static bool operator ==(SensitiveString s1, string s2)
+        public static bool operator ==(SensitiveString? s1, object? s2)
         {
-            return s1.Value == s2;
+            if (s2 is SensitiveString other)
+                return s1?.Value == other?.Value;
+            if (s2 is string otherString)
+                return s1?.Value == otherString;
+            return ReferenceEquals(s1, null) && ReferenceEquals(s2, null);
         }
-        public static bool operator !=(SensitiveString s1, string s2)
+        public static bool operator !=(SensitiveString s1, object? s2)
         {
-            return s1.Value != s2;
+            return !(s1 == s2);
         }
     }
 
-    public static class SensitiveStringExtensions
+    public static class SensitiveStringExtensionMethods
     {
         public static SensitiveString? ToSensitiveString(this string? s)
         {

--- a/source/Octopus.Data/Model/SensitiveString.cs
+++ b/source/Octopus.Data/Model/SensitiveString.cs
@@ -32,7 +32,12 @@ namespace Octopus.Data.Model
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
+            if (obj.GetType() != GetType())
+            {
+                if (obj is string stringObj)
+                    return Value == stringObj;
+                return false;
+            }
             return Equals((SensitiveString) obj);
         }
 

--- a/source/Octopus.Data/Model/SensitiveString.cs
+++ b/source/Octopus.Data/Model/SensitiveString.cs
@@ -39,9 +39,9 @@ namespace Octopus.Data.Model
 
     public static class SensitiveStringExtensionMethods
     {
-        public static SensitiveString? ToSensitiveString(this string? s)
+        public static SensitiveString ToSensitiveString(this string s)
         {
-            return s == null ? null : new SensitiveString(s);
+            return new SensitiveString(s);
         }
     }
 }

--- a/source/Octopus.Data/Model/SensitiveString.cs
+++ b/source/Octopus.Data/Model/SensitiveString.cs
@@ -49,7 +49,7 @@ namespace Octopus.Data.Model
                 return s1?.Value == otherString;
             return ReferenceEquals(s1, null) && ReferenceEquals(s2, null);
         }
-        public static bool operator !=(SensitiveString s1, object? s2)
+        public static bool operator !=(SensitiveString? s1, object? s2)
         {
             return !(s1 == s2);
         }

--- a/source/Octopus.Data/Model/SensitiveString.cs
+++ b/source/Octopus.Data/Model/SensitiveString.cs
@@ -6,7 +6,7 @@ namespace Octopus.Data.Model
     [DebuggerDisplay("Sensitive: {Value}")]
     public class SensitiveString : IEquatable<SensitiveString>, IEquatable<string>
     {
-        public SensitiveString(string value)
+        public SensitiveString(string? value)
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value),
@@ -66,7 +66,7 @@ namespace Octopus.Data.Model
 
     public static class SensitiveStringExtensions
     {
-        public static SensitiveString ToSensitiveString(this string s)
+        public static SensitiveString? ToSensitiveString(this string s)
         {
             if (s == null)
                 return null;

--- a/source/Octopus.Data/Model/SensitiveString.cs
+++ b/source/Octopus.Data/Model/SensitiveString.cs
@@ -38,7 +38,8 @@ namespace Octopus.Data.Model
                     return Value == stringObj;
                 return false;
             }
-            return Equals((SensitiveString) obj);
+
+            return Equals((SensitiveString)obj);
         }
 
         public static bool operator ==(SensitiveString? s1, object? s2)
@@ -49,6 +50,7 @@ namespace Octopus.Data.Model
                 return s1?.Value == otherString;
             return ReferenceEquals(s1, null) && ReferenceEquals(s2, null);
         }
+
         public static bool operator !=(SensitiveString? s1, object? s2)
         {
             return !(s1 == s2);

--- a/source/Octopus.Data/Model/SensitiveString.cs
+++ b/source/Octopus.Data/Model/SensitiveString.cs
@@ -18,14 +18,14 @@ namespace Octopus.Data.Model
 
         public string Value { get; }
 
-        public bool Equals(SensitiveString? other)
+        public bool Equals(SensitiveString other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return Value == other.Value;
         }
 
-        public bool Equals(string? other)
+        public bool Equals(string other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
@@ -45,22 +45,13 @@ namespace Octopus.Data.Model
             return (Value != null ? Value.GetHashCode() : 0);
         }
 
-        public static bool operator ==(SensitiveString? s1, SensitiveString? s2)
+        public static bool operator ==(SensitiveString s1, string s2)
         {
-            return s1?.Value == s2?.Value;
+            return s1.Value == s2;
         }
-        public static bool operator !=(SensitiveString? s1, SensitiveString? s2)
+        public static bool operator !=(SensitiveString s1, string s2)
         {
-            return s1?.Value != s2?.Value;
-        }
-
-        public static bool operator ==(SensitiveString? s1, string? s2)
-        {
-            return s1?.Value == s2;
-        }
-        public static bool operator !=(SensitiveString? s1, string? s2)
-        {
-            return s1?.Value != s2;
+            return s1.Value != s2;
         }
     }
 

--- a/source/Octopus.Data/Model/SensitiveString.cs
+++ b/source/Octopus.Data/Model/SensitiveString.cs
@@ -20,7 +20,20 @@ namespace Octopus.Data.Model
 
         public override int GetHashCode()
         {
-            return (Value != null ? Value.GetHashCode() : 0);
+            return Value.GetHashCode();
+        }
+
+        protected bool Equals(SensitiveString? other)
+        {
+            return Value == other?.Value;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((SensitiveString) obj);
         }
 
         public static bool operator ==(SensitiveString? s1, object? s2)

--- a/source/Octopus.Data/Model/SensitiveString.cs
+++ b/source/Octopus.Data/Model/SensitiveString.cs
@@ -18,21 +18,21 @@ namespace Octopus.Data.Model
 
         public string Value { get; }
 
-        public bool Equals(SensitiveString other)
+        public bool Equals(SensitiveString? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return Value == other.Value;
         }
 
-        public bool Equals(string other)
+        public bool Equals(string? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return Value == other;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
@@ -45,20 +45,20 @@ namespace Octopus.Data.Model
             return (Value != null ? Value.GetHashCode() : 0);
         }
 
-        public static bool operator ==(SensitiveString s1, SensitiveString s2)
+        public static bool operator ==(SensitiveString? s1, SensitiveString? s2)
         {
             return s1?.Value == s2?.Value;
         }
-        public static bool operator !=(SensitiveString s1, SensitiveString s2)
+        public static bool operator !=(SensitiveString? s1, SensitiveString? s2)
         {
             return s1?.Value != s2?.Value;
         }
 
-        public static bool operator ==(SensitiveString s1, string s2)
+        public static bool operator ==(SensitiveString? s1, string? s2)
         {
             return s1?.Value == s2;
         }
-        public static bool operator !=(SensitiveString s1, string s2)
+        public static bool operator !=(SensitiveString? s1, string? s2)
         {
             return s1?.Value != s2;
         }

--- a/source/Octopus.Data/Model/User/Identity.cs
+++ b/source/Octopus.Data/Model/User/Identity.cs
@@ -8,17 +8,13 @@ namespace Octopus.Data.Model.User
 {
     public sealed class Identity : IEquatable<Identity>, IEquatable<IdentityResource>
     {
-        public Identity()
+        public Identity(string identityProviderName)
         {
+            IdentityProviderName = identityProviderName;
             Claims = new Dictionary<string, IdentityClaim>();
         }
 
-        public Identity(string identityProviderName) : this()
-        {
-            IdentityProviderName = identityProviderName;
-        }
-
-        public string IdentityProviderName { get; set; }
+        public string IdentityProviderName { get; }
 
         public Dictionary<string, IdentityClaim> Claims { get; }
 

--- a/source/Octopus.Data/Model/User/Identity.cs
+++ b/source/Octopus.Data/Model/User/Identity.cs
@@ -21,7 +21,8 @@ namespace Octopus.Data.Model.User
         [JsonIgnore]
         public string[] SearchableIdentifiers => Claims
             .Where(kvp => kvp.Value.IsIdentifyingClaim && !string.IsNullOrWhiteSpace(kvp.Value.Value))
-            .Select(kvp => IdentityProviderName + ":" + kvp.Value.Value).ToArray();
+            .Select(kvp => IdentityProviderName + ":" + kvp.Value.Value)
+            .ToArray();
 
         public bool Equals(Identity other)
         {
@@ -36,10 +37,10 @@ namespace Octopus.Data.Model.User
                     return false;
                 var existingClaimValue = kvp.Value.Value;
                 var bothClaimsAreNullOrWhitespace = string.IsNullOrWhiteSpace(existingClaimValue) &&
-                                                    string.IsNullOrWhiteSpace(other.Claims[kvp.Key].Value);
+                    string.IsNullOrWhiteSpace(other.Claims[kvp.Key].Value);
                 var existingClaimHasValueAndMatches = !string.IsNullOrWhiteSpace(existingClaimValue) &&
-                                                      existingClaimValue.Equals(other.Claims[kvp.Key].Value,
-                                                          StringComparison.OrdinalIgnoreCase);
+                    existingClaimValue.Equals(other.Claims[kvp.Key].Value,
+                        StringComparison.OrdinalIgnoreCase);
                 return bothClaimsAreNullOrWhitespace || existingClaimHasValueAndMatches;
             });
         }
@@ -56,10 +57,10 @@ namespace Octopus.Data.Model.User
                     return false;
                 var existingClaimValue = kvp.Value.Value;
                 var bothClaimsAreNullOrWhitespace = string.IsNullOrWhiteSpace(existingClaimValue) &&
-                                                    string.IsNullOrWhiteSpace(other.Claims[kvp.Key].Value);
+                    string.IsNullOrWhiteSpace(other.Claims[kvp.Key].Value);
                 var existingClaimHasValueAndMatches = !string.IsNullOrWhiteSpace(existingClaimValue) &&
-                                                      existingClaimValue.Equals(other.Claims[kvp.Key].Value,
-                                                          StringComparison.OrdinalIgnoreCase);
+                    existingClaimValue.Equals(other.Claims[kvp.Key].Value,
+                        StringComparison.OrdinalIgnoreCase);
                 return bothClaimsAreNullOrWhitespace || existingClaimHasValueAndMatches;
             });
         }
@@ -102,7 +103,7 @@ namespace Octopus.Data.Model.User
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj.GetType() == GetType() && Equals((Identity) obj);
+            return obj.GetType() == GetType() && Equals((Identity)obj);
         }
 
         public override int GetHashCode()

--- a/source/Octopus.Data/Model/User/IdentityClaim.cs
+++ b/source/Octopus.Data/Model/User/IdentityClaim.cs
@@ -2,14 +2,14 @@ namespace Octopus.Data.Model.User
 {
     public class IdentityClaim
     {
-        public IdentityClaim(string value, bool isIdentifyingClaim, bool isServerSideOnly = false)
+        public IdentityClaim(string? value, bool isIdentifyingClaim, bool isServerSideOnly = false)
         {
             Value = value;
             IsIdentifyingClaim = isIdentifyingClaim;
             IsServerSideOnly = isServerSideOnly;
         }
 
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         public bool IsIdentifyingClaim { get; set; }
 

--- a/source/Octopus.Data/Model/User/IdentityClaim.cs
+++ b/source/Octopus.Data/Model/User/IdentityClaim.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Octopus.Data.Model.User
 {
     public class IdentityClaim

--- a/source/Octopus.Data/Model/User/IdentityClaim.cs
+++ b/source/Octopus.Data/Model/User/IdentityClaim.cs
@@ -2,9 +2,6 @@ namespace Octopus.Data.Model.User
 {
     public class IdentityClaim
     {
-        public IdentityClaim()
-        {}
-
         public IdentityClaim(string value, bool isIdentifyingClaim, bool isServerSideOnly = false)
         {
             Value = value;

--- a/source/Octopus.Data/Model/User/User.cs
+++ b/source/Octopus.Data/Model/User/User.cs
@@ -1,4 +1,6 @@
-﻿namespace Octopus.Data.Model.User
+﻿using System;
+
+namespace Octopus.Data.Model.User
 {
     public class User
     {

--- a/source/Octopus.Data/Octopus.Data.csproj
+++ b/source/Octopus.Data/Octopus.Data.csproj
@@ -12,6 +12,8 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <LangVersion>default</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Octopus.Data/Octopus.Data.csproj
+++ b/source/Octopus.Data/Octopus.Data.csproj
@@ -8,7 +8,6 @@
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Data</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageLicenseUrl>https://github.com/OctopusDeploy/Data/blob/main/LICENSE.txt</PackageLicenseUrl>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/source/Octopus.Data/Octopus.Data.csproj
+++ b/source/Octopus.Data/Octopus.Data.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Octopus.Data</AssemblyName>
     <PackageId>Octopus.Data</PackageId>
     <Authors>Octopus Deploy</Authors>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Data</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/OctopusDeploy/Data/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/source/Octopus.Data/Octopus.Data.csproj
+++ b/source/Octopus.Data/Octopus.Data.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Octopus.Data</AssemblyName>
     <PackageId>Octopus.Data</PackageId>
     <Authors>Octopus Deploy</Authors>

--- a/source/Octopus.Data/Octopus.Data.csproj
+++ b/source/Octopus.Data/Octopus.Data.csproj
@@ -14,6 +14,7 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Octopus.Data/Properties/AssemblyInfo.cs
+++ b/source/Octopus.Data/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 
 [assembly: AssemblyDescription("Data interfaces for Octopus, an opinionated deployment solution for .NET applications")]
 [assembly: AssemblyCompany("Octopus Deploy")]

--- a/source/Octopus.Data/ResourceMapperMode.cs
+++ b/source/Octopus.Data/ResourceMapperMode.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Octopus.Data
 {
     public enum ResourceMapperMode

--- a/source/Octopus.Data/Resources/Attributes/AllowConnectivityCheckAttribute.cs
+++ b/source/Octopus.Data/Resources/Attributes/AllowConnectivityCheckAttribute.cs
@@ -10,7 +10,8 @@ namespace Octopus.Data.Resources.Attributes
         public readonly string ConnectivityCheckTitle;
         public readonly string[] DependsOnPropertyNames;
 
-        public AllowConnectivityCheckAttribute(string connectivityCheckTitle, string apiEndpoint,
+        public AllowConnectivityCheckAttribute(string connectivityCheckTitle,
+            string apiEndpoint,
             params string[] dependsOnPropertyNames)
         {
             ConnectivityCheckTitle = connectivityCheckTitle;

--- a/source/Octopus.Data/Resources/Attributes/HasOptionsAttribute.cs
+++ b/source/Octopus.Data/Resources/Attributes/HasOptionsAttribute.cs
@@ -1,4 +1,6 @@
-﻿namespace Octopus.Data.Resources.Attributes
+﻿using System;
+
+namespace Octopus.Data.Resources.Attributes
 {
     /// <summary>
     ///     Indicates that this property is selectable from a list of options, which are implied by the enum type of this

--- a/source/Octopus.Data/Resources/Attributes/ListApiAttribute.cs
+++ b/source/Octopus.Data/Resources/Attributes/ListApiAttribute.cs
@@ -1,4 +1,5 @@
-﻿using Octopus.Data.Model;
+﻿using System;
+using Octopus.Data.Model;
 
 namespace Octopus.Data.Resources.Attributes
 {

--- a/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityAttribute.cs
+++ b/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityAttribute.cs
@@ -8,7 +8,7 @@ namespace Octopus.Data.Resources.Attributes
     [AttributeUsage(AttributeTargets.Property)]
     public abstract class PropertyApplicabilityAttribute : Attribute
     {
-        internal PropertyApplicabilityAttribute(PropertyApplicabilityMode mode, string dependsOnPropertyName, object dependsOnPropertyValue)
+        internal PropertyApplicabilityAttribute(PropertyApplicabilityMode mode, string dependsOnPropertyName, object? dependsOnPropertyValue)
         {
             Mode = mode;
             DependsOnPropertyName = dependsOnPropertyName;
@@ -19,7 +19,7 @@ namespace Octopus.Data.Resources.Attributes
         
         public string DependsOnPropertyName { get; }
         
-        public object DependsOnPropertyValue { get; }
+        public object? DependsOnPropertyValue { get; }
     }
 
     public class ApplicableWhenAnyValueAttribute : PropertyApplicabilityAttribute
@@ -38,14 +38,14 @@ namespace Octopus.Data.Resources.Attributes
 
     public class ApplicableWhenSpecificValueAttribute : PropertyApplicabilityAttribute
     {
-        public ApplicableWhenSpecificValueAttribute(string dependsOnPropertyName, object dependsOnPropertyValue) : 
+        public ApplicableWhenSpecificValueAttribute(string dependsOnPropertyName, object? dependsOnPropertyValue) : 
             base(PropertyApplicabilityMode.ApplicableIfSpecificValue, dependsOnPropertyName, dependsOnPropertyValue)
         {}
     }
 
     public class ApplicableWhenNotSpecificValueAttribute : PropertyApplicabilityAttribute
     {
-        public ApplicableWhenNotSpecificValueAttribute(string dependsOnPropertyName, object dependsOnPropertyValue) : 
+        public ApplicableWhenNotSpecificValueAttribute(string dependsOnPropertyName, object? dependsOnPropertyValue) : 
             base(PropertyApplicabilityMode.ApplicableIfNotSpecificValue, dependsOnPropertyName, dependsOnPropertyValue)
         {}
     }

--- a/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityMode.cs
+++ b/source/Octopus.Data/Resources/Attributes/PropertyApplicabilityMode.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Octopus.Data.Resources.Attributes
 {
     public enum PropertyApplicabilityMode

--- a/source/Octopus.Data/Resources/Attributes/SelectMode.cs
+++ b/source/Octopus.Data/Resources/Attributes/SelectMode.cs
@@ -1,4 +1,6 @@
-﻿namespace Octopus.Data.Resources.Attributes
+﻿using System;
+
+namespace Octopus.Data.Resources.Attributes
 {
     public enum SelectMode
     {

--- a/source/Octopus.Data/Resources/Attributes/SupportsRestrictionAttribute.cs
+++ b/source/Octopus.Data/Resources/Attributes/SupportsRestrictionAttribute.cs
@@ -8,7 +8,7 @@ namespace Octopus.Data.Resources.Attributes
     {
         public SupportsRestrictionAttribute(params string[] scopes)
         {
-            Scopes = (IList<string>) scopes ?? new List<string>();
+            Scopes = (IList<string>)scopes ?? new List<string>();
         }
 
         public IList<string> Scopes { get; }

--- a/source/Octopus.Data/Resources/IAuditedResource.cs
+++ b/source/Octopus.Data/Resources/IAuditedResource.cs
@@ -15,6 +15,6 @@ namespace Octopus.Data.Resources
         /// <summary>
         ///     Gets or sets the username of the user who last modified this resource.
         /// </summary>
-        string LastModifiedBy { get; set; }
+        string? LastModifiedBy { get; set; }
     }
 }

--- a/source/Octopus.Data/Resources/IResource.cs
+++ b/source/Octopus.Data/Resources/IResource.cs
@@ -10,7 +10,7 @@ namespace Octopus.Data.Resources
         /// <summary>
         ///     Gets a unique identifier for this resource.
         /// </summary>
-        string Id { get; }
+        string? Id { get; }
 
         /// <summary>
         ///     Gets or sets a dictionary of links to other related resources. These links can be used to navigate the resources on

--- a/source/Octopus.Data/Resources/IResource.cs
+++ b/source/Octopus.Data/Resources/IResource.cs
@@ -1,4 +1,5 @@
-﻿using Octopus.Data.Model;
+﻿using System;
+using Octopus.Data.Model;
 
 namespace Octopus.Data.Resources
 {

--- a/source/Octopus.Data/Resources/Resource.cs
+++ b/source/Octopus.Data/Resources/Resource.cs
@@ -21,7 +21,7 @@ namespace Octopus.Data.Resources
         /// Gets or sets a unique identifier for this resource.
         /// </summary>
         [JsonProperty(Order = -100, NullValueHandling = NullValueHandling.Ignore)]
-        public string Id { get; set; }
+        public string Id { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the date/time that this resource was last modified.
@@ -33,7 +33,7 @@ namespace Octopus.Data.Resources
         /// Gets or sets the username of the user who last modified this resource.
         /// </summary>
         [JsonProperty(Order = 1002, NullValueHandling = NullValueHandling.Ignore)]
-        public string LastModifiedBy { get; set; }
+        public string LastModifiedBy { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets a dictionary of links to other related resources. These links can be used to navigate the resources on

--- a/source/Octopus.Data/Resources/Resource.cs
+++ b/source/Octopus.Data/Resources/Resource.cs
@@ -21,7 +21,7 @@ namespace Octopus.Data.Resources
         /// Gets or sets a unique identifier for this resource.
         /// </summary>
         [JsonProperty(Order = -100, NullValueHandling = NullValueHandling.Ignore)]
-        public string Id { get; set; } = string.Empty;
+        public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the date/time that this resource was last modified.

--- a/source/Octopus.Data/Resources/Resource.cs
+++ b/source/Octopus.Data/Resources/Resource.cs
@@ -33,7 +33,7 @@ namespace Octopus.Data.Resources
         ///     Gets or sets the username of the user who last modified this resource.
         /// </summary>
         [JsonProperty(Order = 1002, NullValueHandling = NullValueHandling.Ignore)]
-        public string LastModifiedBy { get; set; } = string.Empty;
+        public string? LastModifiedBy { get; set; }
 
         /// <summary>
         ///     Gets or sets a dictionary of links to other related resources. These links can be used to navigate the resources on

--- a/source/Octopus.Data/Resources/ResourceCollection.cs
+++ b/source/Octopus.Data/Resources/ResourceCollection.cs
@@ -16,18 +16,23 @@ namespace Octopus.Data.Resources
             Links = links;
         }
 
-        [JsonProperty(Order = 1)] public string ItemType => typeof(TResource).Name.Replace("Resource", "");
+        [JsonProperty(Order = 1)]
+        public string ItemType => typeof(TResource).Name.Replace("Resource", "");
 
-        [JsonProperty(Order = 4)] public int TotalResults { get; set; }
+        [JsonProperty(Order = 4)]
+        public int TotalResults { get; set; }
 
-        [JsonProperty(Order = 5)] public int ItemsPerPage { get; set; }
+        [JsonProperty(Order = 5)]
+        public int ItemsPerPage { get; set; }
 
         [JsonProperty(Order = 6)]
         public int NumberOfPages =>
-            ItemsPerPage == 0 ? 1 : (int) Math.Max(1, Math.Ceiling((double) TotalResults / ItemsPerPage));
+            ItemsPerPage == 0 ? 1 : (int)Math.Max(1, Math.Ceiling((double)TotalResults / ItemsPerPage));
 
-        [JsonProperty(Order = 6)] public int LastPageNumber => NumberOfPages - 1;
+        [JsonProperty(Order = 6)]
+        public int LastPageNumber => NumberOfPages - 1;
 
-        [JsonProperty(Order = 10)] public IList<TResource> Items { get; set; }
+        [JsonProperty(Order = 10)]
+        public IList<TResource> Items { get; set; }
     }
 }

--- a/source/Octopus.Data/Resources/SensitiveValue.cs
+++ b/source/Octopus.Data/Resources/SensitiveValue.cs
@@ -17,12 +17,12 @@ namespace Octopus.Data.Resources
 
         public static implicit operator SensitiveValue(string newValue)
         {
-            return new SensitiveValue {HasValue = newValue != null};
+            return new SensitiveValue { HasValue = newValue != null };
         }
 
         public static implicit operator SensitiveValue(SensitiveString newValue)
         {
-            return new SensitiveValue {HasValue = newValue?.Value != null};
+            return new SensitiveValue { HasValue = newValue?.Value != null };
         }
     }
 }

--- a/source/Octopus.Data/Resources/SensitiveValue.cs
+++ b/source/Octopus.Data/Resources/SensitiveValue.cs
@@ -6,7 +6,7 @@ namespace Octopus.Data.Resources
     public class SensitiveValue : IEquatable<SensitiveValue>
     {
         public bool HasValue { get; set; }
-        public string NewValue { get; set; }
+        public string? NewValue { get; set; }
 
         public static implicit operator SensitiveValue(string newValue)
         {

--- a/source/Octopus.Data/Resources/Users/IdentityClaimResource.cs
+++ b/source/Octopus.Data/Resources/Users/IdentityClaimResource.cs
@@ -1,18 +1,16 @@
-﻿namespace Octopus.Data.Resources.Users
+﻿
+namespace Octopus.Data.Resources.Users
 {
     public class IdentityClaimResource
     {
-        public IdentityClaimResource()
-        { }
-
         public IdentityClaimResource(string value, bool isIdentifyingClaim)
         {
             Value = value;
             IsIdentifyingClaim = isIdentifyingClaim;
         }
 
-        public string Value { get; set; }
+        public string Value { get; }
 
-        public bool IsIdentifyingClaim { get; set; }
+        public bool IsIdentifyingClaim { get; }
     }
 }

--- a/source/Octopus.Data/Resources/Users/IdentityClaimResource.cs
+++ b/source/Octopus.Data/Resources/Users/IdentityClaimResource.cs
@@ -5,16 +5,15 @@ namespace Octopus.Data.Resources.Users
     {
         public IdentityClaimResource()
         {
-            Value = string.Empty;
         }
 
-        public IdentityClaimResource(string value, bool isIdentifyingClaim)
+        public IdentityClaimResource(string? value, bool isIdentifyingClaim)
         {
             Value = value;
             IsIdentifyingClaim = isIdentifyingClaim;
         }
 
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         public bool IsIdentifyingClaim { get; set; }
     }

--- a/source/Octopus.Data/Resources/Users/IdentityClaimResource.cs
+++ b/source/Octopus.Data/Resources/Users/IdentityClaimResource.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System;
+
 namespace Octopus.Data.Resources.Users
 {
     public class IdentityClaimResource

--- a/source/Octopus.Data/Resources/Users/IdentityResource.cs
+++ b/source/Octopus.Data/Resources/Users/IdentityResource.cs
@@ -7,17 +7,13 @@ namespace Octopus.Data.Resources.Users
 {
     public sealed class IdentityResource : IEquatable<IdentityResource>
     {
-        public IdentityResource()
+        public IdentityResource(string identityProviderName)
         {
+            IdentityProviderName = identityProviderName;
             Claims = new Dictionary<string, IdentityClaimResource>();
         }
 
-        public IdentityResource(string identityProviderName) : this()
-        {
-            IdentityProviderName = identityProviderName;
-        }
-
-        public string IdentityProviderName { get; set; }
+        public string IdentityProviderName { get; }
 
         public Dictionary<string, IdentityClaimResource> Claims { get; }
 
@@ -43,7 +39,7 @@ namespace Octopus.Data.Resources.Users
             {
                 if (Claims.ContainsKey(kvp.Key))
                 {
-                    Claims[kvp.Key].Value = kvp.Value.Value;
+                    Claims[kvp.Key] = new IdentityClaimResource(kvp.Value.Value, kvp.Value.IsIdentifyingClaim);
                 }
                 else
                 {

--- a/source/Octopus.Data/Result.cs
+++ b/source/Octopus.Data/Result.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Octopus.Data
+{
+    public interface IResult
+    {
+        bool WasSuccessful { get; }
+        string[] Errors { get; }
+        string ErrorString { get; }
+        bool WasFailure { get; }
+    }
+
+    public class Result : IResult
+    {
+        private string[] errors;
+
+        private Result()
+        {
+
+        }
+
+        public bool WasSuccessful { get; private set; }
+        public bool WasFailure => !WasSuccessful;
+
+        public string[] Errors => errors.ToArray();
+
+        public string ErrorString => string.Join(Environment.NewLine, errors);
+
+
+        public static Result Failed(params string[] errors)
+        {
+            return new Result() { errors = errors.ToArray() };
+        }
+        public static Result Failed(IReadOnlyList<string> errors)
+        {
+            return new Result() { errors = errors.ToArray() };
+        }
+
+        public static Result Failed(params IResult[] becauseOf)
+        {
+            return new Result() { errors = becauseOf.SelectMany(b => b.Errors).ToArray() };
+        }
+
+        public static Result Success()
+        {
+            return new Result() { WasSuccessful = true };
+        }
+
+        public static Result From(params Result[] results)
+        {
+            var failed = results.Where(r => !r.WasSuccessful).ToArray();
+            if (failed.Length == 0)
+                return Result.Success();
+            return Result.Failed(failed.SelectMany(f => f.Errors).ToArray());
+        }
+    }
+
+    public class Result<T> : IResult
+    {
+        private T value;
+        private string[] errors;
+
+        private Result()
+        {
+
+        }
+
+        public bool WasSuccessful { get; private set; }
+
+        public string[] Errors => errors?.ToArray();
+
+        public string ErrorString => errors != null ? string.Join(Environment.NewLine, errors) : null;
+
+        public T Value
+        {
+            get
+            {
+                if (!WasSuccessful)
+                    throw new Exception("No value as the operation was not successful");
+                return value;
+            }
+        }
+
+        public bool WasFailure => !WasSuccessful;
+
+        public static Result<T> Failed()
+        {
+            return new Result<T>() { errors = new string[0] };
+        }
+
+        public static Result<T> Failed(params string[] errors)
+        {
+            return new Result<T>() { errors = errors.ToArray() };
+        }
+
+        public static Result<T> Failed(params IResult[] becauseOf)
+        {
+            return new Result<T>() { errors = becauseOf.Where(s => s.WasFailure).SelectMany(b => b.Errors).ToArray() };
+        }
+
+        public static Result<T> Failed(IReadOnlyCollection<IResult> becauseOf)
+        {
+            return new Result<T>() { errors = becauseOf.Where(s => s.WasFailure).SelectMany(b => b.Errors).ToArray() };
+        }
+
+        public static Result<T> Success(T value)
+        {
+            return new Result<T>() { WasSuccessful = true, value = value };
+        }
+
+        public static implicit operator Result<T>(T value)
+        {
+            return Success(value);
+        }
+
+        public static implicit operator T(Result<T> result)
+        {
+            return result.Value;
+        }
+
+        public T ValueOr(T def)
+        {
+            return WasSuccessful ? Value : def;
+        }
+
+        public override string ToString()
+        {
+            return WasSuccessful
+                ? "" + Value
+                : ErrorString;
+        }
+
+        public static Result<T> From<TIn>(Result<TIn> result) where TIn : T
+        {
+            return result.WasSuccessful
+                ? Success(result.Value)
+                : Failed(result);
+        }
+    }}

--- a/source/Octopus.Data/Result.cs
+++ b/source/Octopus.Data/Result.cs
@@ -72,9 +72,9 @@ namespace Octopus.Data
 
         public string ErrorString => Errors != null && Errors.Any() ? string.Join(Environment.NewLine, Errors) : string.Empty;
 
-        [MaybeNull, AllowNull]
         public T Value
         {
+            [return: MaybeNull]
             get
             {
                 if (!WasSuccessful)

--- a/source/Octopus.Data/Result.cs
+++ b/source/Octopus.Data/Result.cs
@@ -16,9 +16,8 @@ namespace Octopus.Data
     {
         private string[] errors = Array.Empty<string>();
 
-        private Result()
+        protected Result()
         {
-
         }
 
         public bool WasSuccessful { get; private set; }

--- a/source/Octopus.Data/Result.cs
+++ b/source/Octopus.Data/Result.cs
@@ -62,7 +62,7 @@ namespace Octopus.Data
         private T value;
         private string[] errors = Array.Empty<string>();
 
-        private Result()
+        protected Result()
         {
         }
 

--- a/source/Octopus.Data/Result.cs
+++ b/source/Octopus.Data/Result.cs
@@ -15,7 +15,7 @@ namespace Octopus.Data
 
     public class Result : IResult
     {
-        private string[] errors = Array.Empty<string>();
+        string[] errors = Array.Empty<string>();
 
         protected Result()
         {
@@ -28,11 +28,11 @@ namespace Octopus.Data
 
         public string ErrorString => string.Join(Environment.NewLine, errors);
 
-
         public static Result Failed(params string[] errors)
         {
             return new Result { errors = errors.ToArray() };
         }
+
         public static Result Failed(IReadOnlyList<string> errors)
         {
             return new Result { errors = errors.ToArray() };
@@ -52,15 +52,15 @@ namespace Octopus.Data
         {
             var failed = results.Where(r => !r.WasSuccessful).ToArray();
             if (failed.Length == 0)
-                return Result.Success();
-            return Result.Failed(failed.SelectMany(f => f.Errors).ToArray());
+                return Success();
+            return Failed(failed.SelectMany(f => f.Errors).ToArray());
         }
     }
 
     public class Result<T> : IResult
     {
         [AllowNull]
-        private T value = default(T);
+        T value;
 
         protected Result()
         {
@@ -88,27 +88,32 @@ namespace Octopus.Data
 
         public static Result<T> Failed()
         {
-            return new Result<T>() { Errors = new string[0] };
+            return new Result<T>
+                { Errors = new string[0] };
         }
 
         public static Result<T> Failed(params string[] errors)
         {
-            return new Result<T>() { Errors = errors.ToArray() };
+            return new Result<T>
+                { Errors = errors.ToArray() };
         }
 
         public static Result<T> Failed(params IResult[] becauseOf)
         {
-            return new Result<T>() { Errors = becauseOf.Where(s => s.WasFailure).SelectMany(b => b.Errors).ToArray() };
+            return new Result<T>
+                { Errors = becauseOf.Where(s => s.WasFailure).SelectMany(b => b.Errors).ToArray() };
         }
 
         public static Result<T> Failed(IReadOnlyCollection<IResult> becauseOf)
         {
-            return new Result<T>() { Errors = becauseOf.Where(s => s.WasFailure).SelectMany(b => b.Errors).ToArray() };
+            return new Result<T>
+                { Errors = becauseOf.Where(s => s.WasFailure).SelectMany(b => b.Errors).ToArray() };
         }
 
         public static Result<T> Success(T value)
         {
-            return new Result<T>() { WasSuccessful = true, Value = value };
+            return new Result<T>
+                { WasSuccessful = true, Value = value };
         }
 
         public static implicit operator Result<T>(T value)

--- a/source/Octopus.Data/Result.cs
+++ b/source/Octopus.Data/Result.cs
@@ -66,7 +66,7 @@ namespace Octopus.Data
         {
         }
 
-        public bool WasSuccessful { get; private set; }
+        public bool WasSuccessful { get; protected set; }
 
         public string[] Errors => errors.ToArray();
 
@@ -80,6 +80,7 @@ namespace Octopus.Data
                     throw new Exception("No value as the operation was not successful");
                 return value;
             }
+            protected set => this.value = value;
         }
 
         public bool WasFailure => !WasSuccessful;
@@ -106,7 +107,7 @@ namespace Octopus.Data
 
         public static Result<T> Success(T value)
         {
-            return new Result<T>() { WasSuccessful = true, value = value };
+            return new Result<T>() { WasSuccessful = true, Value = value };
         }
 
         public static implicit operator Result<T>(T value)

--- a/source/Octopus.Data/Result.cs
+++ b/source/Octopus.Data/Result.cs
@@ -60,7 +60,9 @@ namespace Octopus.Data
     public class Result<T> : IResult
     {
         [AllowNull]
-        T value;
+        // ReSharper disable once RedundantDefaultMemberInitializer
+        // ReSharper disable once RedundantTypeSpecificationInDefaultExpression
+        T value = default(T);
 
         protected Result()
         {

--- a/source/Octopus.Data/Result.cs
+++ b/source/Octopus.Data/Result.cs
@@ -60,7 +60,6 @@ namespace Octopus.Data
     public class Result<T> : IResult
     {
         private T value;
-        private string[] errors = Array.Empty<string>();
 
         protected Result()
         {
@@ -68,9 +67,9 @@ namespace Octopus.Data
 
         public bool WasSuccessful { get; protected set; }
 
-        public string[] Errors => errors.ToArray();
+        public string[] Errors { get; protected set; } = Array.Empty<string>();
 
-        public string ErrorString => errors != null && errors.Any() ? string.Join(Environment.NewLine, errors) : string.Empty;
+        public string ErrorString => Errors != null && Errors.Any() ? string.Join(Environment.NewLine, Errors) : string.Empty;
 
         public T Value
         {
@@ -87,22 +86,22 @@ namespace Octopus.Data
 
         public static Result<T> Failed()
         {
-            return new Result<T>() { errors = new string[0] };
+            return new Result<T>() { Errors = new string[0] };
         }
 
         public static Result<T> Failed(params string[] errors)
         {
-            return new Result<T>() { errors = errors.ToArray() };
+            return new Result<T>() { Errors = errors.ToArray() };
         }
 
         public static Result<T> Failed(params IResult[] becauseOf)
         {
-            return new Result<T>() { errors = becauseOf.Where(s => s.WasFailure).SelectMany(b => b.Errors).ToArray() };
+            return new Result<T>() { Errors = becauseOf.Where(s => s.WasFailure).SelectMany(b => b.Errors).ToArray() };
         }
 
         public static Result<T> Failed(IReadOnlyCollection<IResult> becauseOf)
         {
-            return new Result<T>() { errors = becauseOf.Where(s => s.WasFailure).SelectMany(b => b.Errors).ToArray() };
+            return new Result<T>() { Errors = becauseOf.Where(s => s.WasFailure).SelectMany(b => b.Errors).ToArray() };
         }
 
         public static Result<T> Success(T value)

--- a/source/Octopus.Data/Result.cs
+++ b/source/Octopus.Data/Result.cs
@@ -14,7 +14,7 @@ namespace Octopus.Data
 
     public class Result : IResult
     {
-        private string[] errors;
+        private string[] errors = Array.Empty<string>();
 
         private Result()
         {
@@ -31,21 +31,21 @@ namespace Octopus.Data
 
         public static Result Failed(params string[] errors)
         {
-            return new Result() { errors = errors.ToArray() };
+            return new Result { errors = errors.ToArray() };
         }
         public static Result Failed(IReadOnlyList<string> errors)
         {
-            return new Result() { errors = errors.ToArray() };
+            return new Result { errors = errors.ToArray() };
         }
 
         public static Result Failed(params IResult[] becauseOf)
         {
-            return new Result() { errors = becauseOf.SelectMany(b => b.Errors).ToArray() };
+            return new Result { errors = becauseOf.SelectMany(b => b.Errors).ToArray() };
         }
 
         public static Result Success()
         {
-            return new Result() { WasSuccessful = true };
+            return new Result { WasSuccessful = true };
         }
 
         public static Result From(params Result[] results)
@@ -57,21 +57,21 @@ namespace Octopus.Data
         }
     }
 
+#nullable disable
     public class Result<T> : IResult
     {
         private T value;
-        private string[] errors;
+        private string[] errors = Array.Empty<string>();
 
         private Result()
         {
-
         }
 
         public bool WasSuccessful { get; private set; }
 
-        public string[] Errors => errors?.ToArray();
+        public string[] Errors => errors.ToArray();
 
-        public string ErrorString => errors != null ? string.Join(Environment.NewLine, errors) : null;
+        public string ErrorString => errors != null && errors.Any() ? string.Join(Environment.NewLine, errors) : string.Empty;
 
         public T Value
         {
@@ -138,4 +138,6 @@ namespace Octopus.Data
                 ? Success(result.Value)
                 : Failed(result);
         }
-    }}
+    }
+#nullable enable
+}

--- a/source/Octopus.Data/ResultExtensionMethods.cs
+++ b/source/Octopus.Data/ResultExtensionMethods.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Octopus.Data
+{
+    public static class ResultExtensionMethods
+    {
+        public static Result<TOut> Then<TIn, TOut>(
+            this IReadOnlyCollection<Result<TIn>> results,
+            Func<IEnumerable<TIn>, TOut> ifAllSuccessful
+        )
+        {
+            if (results.All(r => r.WasSuccessful))
+                return ifAllSuccessful(results.Select(r => r.Value));
+
+            return Result<TOut>.Failed(results);
+        }
+
+        public static Result<TOut> Then<TIn, TOut>(
+            this Result<TIn> result,
+            Func<TIn, Result<TOut>> ifSuccessful
+        )
+        {
+            return result.WasSuccessful ? ifSuccessful(result.Value) : Result<TOut>.Failed(result);
+        }
+
+        public static Result<TOut> Then<TIn, TOut>(
+            this Result<TIn> result,
+            Func<TIn, TOut> ifSuccessful
+        )
+        {
+            return result.WasSuccessful ? Result<TOut>.Success(ifSuccessful(result.Value)) : Result<TOut>.Failed(result);
+        }
+
+        public static Result<IReadOnlyList<T>> InvertToList<T>(this IEnumerable<Result<T>> results)
+        {
+            IReadOnlyList<Result<T>> resultsArr = results.ToArray();
+            if (resultsArr.All(r => r.WasSuccessful))
+                return Result<IReadOnlyList<T>>.Success(resultsArr.Select(r => r.Value).ToArray());
+            return Result<IReadOnlyList<T>>.Failed(resultsArr);
+        }
+
+        public static Result<TOut> Combine<TA, TB, TOut>(this Result<TA> a, Result<TB> b, Func<TA, TB, TOut> transform)
+        {
+            if (a.WasSuccessful && b.WasSuccessful)
+                return transform(a.Value, b.Value);
+            return Result<TOut>.Failed(a, b);
+        }
+
+        public static Result<T> If<T>(this Result<T> a, IResult b)
+        {
+            if (a.WasSuccessful && b.WasSuccessful)
+                return a.Value;
+            return Result<T>.Failed(a, b);
+        }
+
+        public static Result<T> If<T>(this IResult a, Result<T> b)
+        {
+            if (a.WasSuccessful && b.WasSuccessful)
+                return b.Value;
+            return Result<T>.Failed(a, b);
+        }
+
+        public static Result<T> AsSuccessResult<T>(this T value)
+            => Result<T>.Success(value);
+    }
+}

--- a/source/Octopus.Data/ResultExtensionMethods.cs
+++ b/source/Octopus.Data/ResultExtensionMethods.cs
@@ -13,7 +13,7 @@ namespace Octopus.Data
         {
             if (results.All(r => r.WasSuccessful))
             {
-                return ifAllSuccessful(results.Select(r => r.Value!));
+                return ifAllSuccessful(results.Select(r => r.Value!))!;
             }
 
             return Result<TOut>.Failed(results);
@@ -46,7 +46,7 @@ namespace Octopus.Data
         public static Result<TOut> Combine<TA, TB, TOut>(this Result<TA> a, Result<TB> b, Func<TA, TB, TOut> transform)
         {
             if (a.WasSuccessful && b.WasSuccessful)
-                return transform(a.Value!, b.Value!);
+                return transform(a.Value!, b.Value!)!;
             return Result<TOut>.Failed(a, b);
         }
 

--- a/source/Octopus.Data/ResultExtensionMethods.cs
+++ b/source/Octopus.Data/ResultExtensionMethods.cs
@@ -12,7 +12,9 @@ namespace Octopus.Data
         )
         {
             if (results.All(r => r.WasSuccessful))
-                return ifAllSuccessful(results.Select(r => r.Value));
+            {
+                return ifAllSuccessful(results.Select(r => r.Value!));
+            }
 
             return Result<TOut>.Failed(results);
         }
@@ -22,7 +24,7 @@ namespace Octopus.Data
             Func<TIn, Result<TOut>> ifSuccessful
         )
         {
-            return result.WasSuccessful ? ifSuccessful(result.Value) : Result<TOut>.Failed(result);
+            return result.WasSuccessful ? ifSuccessful(result.Value!) : Result<TOut>.Failed(result);
         }
 
         public static Result<TOut> Then<TIn, TOut>(
@@ -30,35 +32,35 @@ namespace Octopus.Data
             Func<TIn, TOut> ifSuccessful
         )
         {
-            return result.WasSuccessful ? Result<TOut>.Success(ifSuccessful(result.Value)) : Result<TOut>.Failed(result);
+            return result.WasSuccessful ? Result<TOut>.Success(ifSuccessful(result.Value!)) : Result<TOut>.Failed(result);
         }
 
         public static Result<IReadOnlyList<T>> InvertToList<T>(this IEnumerable<Result<T>> results)
         {
             IReadOnlyList<Result<T>> resultsArr = results.ToArray();
             if (resultsArr.All(r => r.WasSuccessful))
-                return Result<IReadOnlyList<T>>.Success(resultsArr.Select(r => r.Value).ToArray());
+                return Result<IReadOnlyList<T>>.Success(resultsArr.Select(r => r.Value!).ToArray());
             return Result<IReadOnlyList<T>>.Failed(resultsArr);
         }
 
         public static Result<TOut> Combine<TA, TB, TOut>(this Result<TA> a, Result<TB> b, Func<TA, TB, TOut> transform)
         {
             if (a.WasSuccessful && b.WasSuccessful)
-                return transform(a.Value, b.Value);
+                return transform(a.Value!, b.Value!);
             return Result<TOut>.Failed(a, b);
         }
 
         public static Result<T> If<T>(this Result<T> a, IResult b)
         {
             if (a.WasSuccessful && b.WasSuccessful)
-                return a.Value;
+                return a.Value!;
             return Result<T>.Failed(a, b);
         }
 
         public static Result<T> If<T>(this IResult a, Result<T> b)
         {
             if (a.WasSuccessful && b.WasSuccessful)
-                return b.Value;
+                return b.Value!;
             return Result<T>.Failed(a, b);
         }
 

--- a/source/Octopus.Data/Storage/User/ApiKeyDescriptor.cs
+++ b/source/Octopus.Data/Storage/User/ApiKeyDescriptor.cs
@@ -1,4 +1,6 @@
-﻿namespace Octopus.Data.Storage.User
+﻿using System;
+
+namespace Octopus.Data.Storage.User
 {
     public class ApiKeyDescriptor
     {

--- a/source/Octopus.Data/Storage/User/ApiKeyDescriptor.cs
+++ b/source/Octopus.Data/Storage/User/ApiKeyDescriptor.cs
@@ -13,7 +13,7 @@
             ApiKey = apiKey;
         }
 
-        public string Purpose { get; private set; }
-        public string ApiKey { get; set; }
+        public string Purpose { get; }
+        public string? ApiKey { get; }
     }
 }

--- a/source/Octopus.Data/Storage/User/ProviderUserGroups.cs
+++ b/source/Octopus.Data/Storage/User/ProviderUserGroups.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Octopus.Data.Storage.User

--- a/source/Octopus.Data/Storage/User/ProviderUserGroups.cs
+++ b/source/Octopus.Data/Storage/User/ProviderUserGroups.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Octopus.Data.Storage.User
 {
     public class ProviderUserGroups
     {
-        public string IdentityProviderName { get; set; }
-        public IEnumerable<string> GroupIds { get; set; }
+        public string IdentityProviderName { get; set; } = string.Empty;
+        public IEnumerable<string> GroupIds { get; set; } = Enumerable.Empty<string>();
     }
 }

--- a/source/OctopusData.sln.DotSettings
+++ b/source/OctopusData.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>

--- a/source/OctopusData.sln.DotSettings
+++ b/source/OctopusData.sln.DotSettings
@@ -1,4 +1,9 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantToStringCall/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantToStringCallForValueType/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StaticMemberInGenericType/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_BINARY_EXPRESSIONS_CHAIN/@EntryValue">False</s:Boolean>
 	
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
@@ -16,26 +21,167 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_EMBEDDED_ARRANGEMENT/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_EMBEDDED_ARRANGEMENT/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_EMBEDDED_BLOCK_ARRANGEMENT/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_INITIALIZER_ARRANGEMENT/@EntryValue">True</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_ATTRIBUTE_LENGTH_FOR_SAME_LINE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_FORMAL_PARAMETERS_ON_LINE/@EntryValue">4</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_INVOCATION_ARGUMENTS_ON_LINE/@EntryValue">4</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ANONYMOUSMETHOD_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_STATEMENT_ON_SAME_LINE/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_SIZEOF_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_TYPEOF_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_BINARY_EXPRESSIONS/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_BINARY_OPSIGN/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_FIRST_TYPE_PARAMETER_CONSTRAINT/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_BINARY_EXPRESSIONS/@EntryValue">WRAP_IF_LONG</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_METHOD_CALLS/@EntryValue">CHOP_IF_LONG</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_EXTENDS_LIST_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_EXTENDS_LIST_STYLE/@EntryValue">WRAP_IF_LONG</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">700</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_OBJECT_AND_COLLECTION_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_PARAMETERS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/IndentTagContent/@EntryValue">DoNotTouch</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/LinebreaksInsideMultilineTag/@EntryValue">False</s:Boolean>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/MaxBlankLines/@EntryValue">1</s:Int64>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/TagAttributeIndenting/@EntryValue">ByFirstAttr</s:String>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/WrapLimit/@EntryValue">300</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/WRAP_LIMIT/@EntryValue">300</s:Int64>
+	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
+&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
+  &lt;TypePattern DisplayName="COM interfaces or structs"&gt;&#xD;
+    &lt;TypePattern.Match&gt;&#xD;
+      &lt;Or&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Interface" /&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute Name="System.Runtime.InteropServices.InterfaceTypeAttribute" /&gt;&#xD;
+            &lt;HasAttribute Name="System.Runtime.InteropServices.ComImport" /&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+        &lt;Kind Is="Struct" /&gt;&#xD;
+      &lt;/Or&gt;&#xD;
+    &lt;/TypePattern.Match&gt;&#xD;
+  &lt;/TypePattern&gt;&#xD;
+  &lt;TypePattern DisplayName="NUnit Test Fixtures" RemoveRegions="All"&gt;&#xD;
+    &lt;TypePattern.Match&gt;&#xD;
+      &lt;And&gt;&#xD;
+        &lt;Kind Is="Class" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestFixtureAttribute" Inherited="True" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestCaseFixtureAttribute" Inherited="True" /&gt;&#xD;
+      &lt;/And&gt;&#xD;
+    &lt;/TypePattern.Match&gt;&#xD;
+    &lt;Entry DisplayName="Setup/Teardown Methods"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Method" /&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.SetUpAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.TearDownAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureSetUpAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureTearDownAttribute" Inherited="True" /&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="All other members" /&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Test Methods"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Method" /&gt;&#xD;
+          &lt;HasAttribute Name="NUnit.Framework.TestAttribute" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/TypePattern&gt;&#xD;
+  &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Public Delegates"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Access Is="Public" /&gt;&#xD;
+          &lt;Kind Is="Delegate" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Public Enums"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Access Is="Public" /&gt;&#xD;
+          &lt;Kind Is="Enum" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Static Fields and Constants"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Or&gt;&#xD;
+          &lt;Kind Is="Constant" /&gt;&#xD;
+          &lt;And&gt;&#xD;
+            &lt;Kind Is="Field" /&gt;&#xD;
+            &lt;Static /&gt;&#xD;
+          &lt;/And&gt;&#xD;
+        &lt;/Or&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Kind Order="Constant Field" /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Fields"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Field" /&gt;&#xD;
+          &lt;Not&gt;&#xD;
+            &lt;Static /&gt;&#xD;
+          &lt;/Not&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Readonly /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Constructors"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Kind Is="Constructor" /&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Static /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Properties, Indexers"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Or&gt;&#xD;
+          &lt;Kind Is="Property" /&gt;&#xD;
+          &lt;Kind Is="Indexer" /&gt;&#xD;
+        &lt;/Or&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="All other members" /&gt;&#xD;
+    &lt;Entry DisplayName="Nested Types"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;Kind Is="Type" /&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/TypePattern&gt;&#xD;
+&lt;/Patterns&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpUsing/KeepImports/=System/@EntryIndexedValue">System</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpUsing/MandatoryImports/=System/@EntryIndexedValue">System</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AD/@EntryIndexedValue">AD</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CSS/@EntryIndexedValue">CSS</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SSL/@EntryIndexedValue">SSL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=MethodPropertyEvent/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AaBb_AaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+</wpf:ResourceDictionary>

--- a/source/OctopusData.sln.DotSettings
+++ b/source/OctopusData.sln.DotSettings
@@ -1,3 +1,41 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_BINARY_EXPRESSIONS_CHAIN/@EntryValue">False</s:Boolean>
+	
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_INTERNAL_MODIFIER/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_PRIVATE_MODIFIER/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_ATTRIBUTE_STYLE/@EntryValue">SEPARATE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FIXED_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FOR_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FOREACH_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_IFELSE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_ANONYMOUS_METHOD_BLOCK/@EntryValue">False</s:Boolean>
+	
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_EMBEDDED_ARRANGEMENT/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_INITIALIZER_ARRANGEMENT/@EntryValue">True</s:Boolean>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_ATTRIBUTE_LENGTH_FOR_SAME_LINE/@EntryValue">1</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_FORMAL_PARAMETERS_ON_LINE/@EntryValue">4</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_INVOCATION_ARGUMENTS_ON_LINE/@EntryValue">4</s:Int64>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ANONYMOUSMETHOD_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_STATEMENT_ON_SAME_LINE/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_SIZEOF_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_TYPEOF_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_BINARY_EXPRESSIONS/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_METHOD_CALLS/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_EXTENDS_LIST_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">700</s:Int64>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_OBJECT_AND_COLLECTION_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_PARAMETERS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=MethodPropertyEvent/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AaBb_AaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>

--- a/source/Tests/IdentityResourceTests.cs
+++ b/source/Tests/IdentityResourceTests.cs
@@ -43,18 +43,20 @@ namespace Tests
             Assert.IsTrue(identity1.Equals(identity2));
         }
 
-        Identity CreateIdentity(string email, bool emailIsIdentifying, string upn, string displayName)
+        Identity CreateIdentity(string? email, bool emailIsIdentifying, string upn, string displayName)
         {
             var identity = new Identity("Test Provider");
-            identity.Claims.Add("email", new IdentityClaim(email, emailIsIdentifying));
+            if (email != null)
+                identity.Claims.Add("email", new IdentityClaim(email, emailIsIdentifying));
             identity.Claims.Add("upn", new IdentityClaim(upn, true));
             return identity;
         }
 
-        IdentityResource CreateIdentityResource(string email, bool emailIsIdentifying, string upn, string displayName)
+        IdentityResource CreateIdentityResource(string? email, bool emailIsIdentifying, string upn, string displayName)
         {
             var identity = new IdentityResource("Test Provider");
-            identity.Claims.Add("email", new IdentityClaimResource(email, emailIsIdentifying));
+            if (email != null)
+                identity.Claims.Add("email", new IdentityClaimResource(email, emailIsIdentifying));
             identity.Claims.Add("upn", new IdentityClaimResource(upn, true));
             return identity;
         }

--- a/source/Tests/IdentityResourceTests.cs
+++ b/source/Tests/IdentityResourceTests.cs
@@ -46,8 +46,7 @@ namespace Tests
         Identity CreateIdentity(string? email, bool emailIsIdentifying, string upn, string displayName)
         {
             var identity = new Identity("Test Provider");
-            if (email != null)
-                identity.Claims.Add("email", new IdentityClaim(email, emailIsIdentifying));
+            identity.Claims.Add("email", new IdentityClaim(email, emailIsIdentifying));
             identity.Claims.Add("upn", new IdentityClaim(upn, true));
             return identity;
         }

--- a/source/Tests/IdentityResourceTests.cs
+++ b/source/Tests/IdentityResourceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using Octopus.Data.Model.User;
 using Octopus.Data.Resources.Users;

--- a/source/Tests/IdentityTests.cs
+++ b/source/Tests/IdentityTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using Octopus.Data.Model.User;
 

--- a/source/Tests/IdentityTests.cs
+++ b/source/Tests/IdentityTests.cs
@@ -45,8 +45,7 @@ namespace Tests
         Identity CreateIdentity(string? email, bool emailIsIdentifying, string upn, string displayName)
         {
             var identity = new Identity("Test Provider");
-            if (email != null)
-                identity.Claims.Add("email", new IdentityClaim(email, emailIsIdentifying));
+            identity.Claims.Add("email", new IdentityClaim(email, emailIsIdentifying));
             identity.Claims.Add("upn", new IdentityClaim(upn, true));
             return identity;
         }

--- a/source/Tests/IdentityTests.cs
+++ b/source/Tests/IdentityTests.cs
@@ -42,10 +42,11 @@ namespace Tests
             Assert.IsTrue(identity1.Equals(identity2));
         }
 
-        Identity CreateIdentity(string email, bool emailIsIdentifying, string upn, string displayName)
+        Identity CreateIdentity(string? email, bool emailIsIdentifying, string upn, string displayName)
         {
             var identity = new Identity("Test Provider");
-            identity.Claims.Add("email", new IdentityClaim(email, emailIsIdentifying));
+            if (email != null)
+                identity.Claims.Add("email", new IdentityClaim(email, emailIsIdentifying));
             identity.Claims.Add("upn", new IdentityClaim(upn, true));
             return identity;
         }

--- a/source/Tests/SensitiveStringTests.cs
+++ b/source/Tests/SensitiveStringTests.cs
@@ -12,7 +12,7 @@ namespace Tests
             var a = "Test Value".ToSensitiveString();
             var b = "Test Value".ToSensitiveString();
             
-            Assert.IsFalse(a == b);
+            Assert.IsTrue(a == b);
         }
 
         [Test]
@@ -46,6 +46,14 @@ namespace Tests
             var a = "Test Value".ToSensitiveString();
             
             Assert.IsFalse(a == null);
+        }
+        
+        [Test]
+        public void ComparingNullSensitiveStringsToNullWorks()
+        {
+            SensitiveString? a = null;
+            
+            Assert.IsTrue(a == null);
         }
     }
 }

--- a/source/Tests/SensitiveStringTests.cs
+++ b/source/Tests/SensitiveStringTests.cs
@@ -7,16 +7,16 @@ namespace Tests
     public class SensitiveStringTests
     {
         [Test]
-        public void ComparingSensitiveStringsAreEqualWorks()
+        public void ComparingSensitiveStringPointersAreEqualWorks()
         {
             var a = "Test Value".ToSensitiveString();
             var b = "Test Value".ToSensitiveString();
             
-            Assert.IsTrue(a == b);
+            Assert.IsFalse(a == b);
         }
 
         [Test]
-        public void ComparingSensitiveStringsAreNotEqualWorks()
+        public void ComparingSensitiveStringPointersAreNotEqualWorks()
         {
             var a = "Test Value".ToSensitiveString();
             var b = "Test Value2".ToSensitiveString();
@@ -38,6 +38,14 @@ namespace Tests
             var a = "Test Value".ToSensitiveString();
             
             Assert.IsTrue(a != "Test Value2");
+        }
+        
+        [Test]
+        public void ComparingSensitiveStringsToNullWorks()
+        {
+            var a = "Test Value".ToSensitiveString();
+            
+            Assert.IsFalse(a == null);
         }
     }
 }

--- a/source/Tests/SensitiveStringTests.cs
+++ b/source/Tests/SensitiveStringTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using Octopus.Data.Model;
 
@@ -47,20 +48,20 @@ namespace Tests
 
             Assert.IsTrue(a != "Test Value2");
         }
-        
+
         [Test]
         public void ComparingSensitiveStringsToNullWorks()
         {
             var a = "Test Value".ToSensitiveString();
-            
+
             Assert.IsFalse(a == null);
         }
-        
+
         [Test]
         public void ComparingNullSensitiveStringsToNullWorks()
         {
             SensitiveString? a = null;
-            
+
             Assert.IsTrue(a == null);
         }
     }

--- a/source/Tests/SensitiveStringTests.cs
+++ b/source/Tests/SensitiveStringTests.cs
@@ -25,11 +25,19 @@ namespace Tests
         }
 
         [Test]
-        public void ComparingSensitiveStringsToEqualStringWorks()
+        public void ComparingSensitiveStringsToEqualOperatorStringWorks()
         {
             var a = "Test Value".ToSensitiveString();
 
             Assert.IsTrue(a == "Test Value");
+        }
+
+        [Test]
+        public void ComparingSensitiveStringsToEqualMethodStringWorks()
+        {
+            var a = "Test Value".ToSensitiveString();
+
+            Assert.IsTrue(a.Equals("Test Value"));
         }
 
         [Test]

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
+
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This involved a number of changes to classes in this library. Most were changes to the ctors to force required things, where we'd been relying on object initializers and everyone setting the properties correctly.

`Result<T>` has also been moved to here, from the server codebase. It is used in cases where we want to return an object that explains reasons, rather than just a null.