### PR TITLE
GitVersion.yml main as a copy of master

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,12 @@
 mode: ContinuousDeployment
 
 branches:
-  master:
-    regex: ^(main|master)$
-    source-branches: ["main"]
+  main:
+    regex: ^main
+    mode: ContinuousDelivery
+    tag: ''
+    increment: Patch
+    prevent-increment-of-merged-branch-version: true
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: false

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,11 +2,16 @@ mode: ContinuousDeployment
 
 branches:
   main:
-    regex: ^main
     mode: ContinuousDelivery
     tag: ''
     increment: Patch
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
+    regex: ^main$
+    source-branches:
+    - develop
+    - release
     tracks-release-branches: false
     is-release-branch: false
+    is-mainline: true
+    pre-release-weight: 55000

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,17 +1,5 @@
 mode: ContinuousDeployment
 
 branches:
-  main:
-    mode: ContinuousDelivery
-    tag: ''
-    increment: Patch
-    prevent-increment-of-merged-branch-version: true
-    track-merge-target: false
-    regex: ^main$
-    source-branches:
-    - develop
-    - release
-    tracks-release-branches: false
-    is-release-branch: false
-    is-mainline: true
-    pre-release-weight: 55000
+  master:
+    regex: ^(main|master)$


### PR DESCRIPTION
The build was failing with the following exception:

```
    System.Collections.Generic.KeyNotFoundException: The given key 'main' was not present in the dictionary.
13:04:34
       at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
13:04:34
       at GitVersion.RepositoryMetadataProvider.<>c__DisplayClass33_0.<GetMergeCommitsForBranch>b__0(String sb) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Core\RepositoryMetadataProvider.cs:line 475
13:04:34
       at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
13:04:34
       at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
13:04:34
       at GitVersion.RepositoryMetadataProvider.<>c__DisplayClass33_0.<GetMergeCommitsForBranch>b__1(Branch b) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Core\RepositoryMetadataProvider.cs:line 480
13:04:34
       at System.Linq.Utilities.<>c__DisplayClass1_0`1.<CombinePredicates>b__0(TSource x)
13:04:34
       at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
13:04:34
       at System.Linq.Enumerable.WhereEnumerableIterator`1.ToArray()
13:04:34
       at System.Linq.OrderedEnumerable`1.ToList()
13:04:34
       at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
13:04:34
       at GitVersion.RepositoryMetadataProvider.GetMergeCommitsForBranch(Branch branch, Config configuration, IEnumerable`1 excludedBranches) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Core\RepositoryMetadataProvider.cs:line 476
13:04:34
       at GitVersion.RepositoryMetadataProvider.FindCommitBranchWasBranchedFrom(Branch branch, Config configuration, Branch[] excludedBranches) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Core\RepositoryMetadataProvider.cs:line 333
13:04:34
       at GitVersion.Configuration.BranchConfigurationCalculator.InheritBranchConfiguration(Branch targetBranch, BranchConfig branchConfiguration, Commit currentCommit, Config configuration, IList`1 excludedInheritBranches) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Configuration\BranchConfigurationCalculator.cs:line 80
13:04:34
       at GitVersion.Configuration.BranchConfigurationCalculator.GetBranchConfiguration(Branch targetBranch, Commit currentCommit, Config configuration, IList`1 excludedInheritBranches) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Configuration\BranchConfigurationCalculator.cs:line 48
```

It looks like this is due to a problem in the branch graph controlled by the `source-branches` YAML configuration.

The default configuration for `master` is defined [here](https://github.com/GitTools/GitVersion/blob/7dbed1eb4268d4e4eac2d18e40fd0bd2f555f66f/src/GitVersionCore/Configuration/ConfigurationBuilder.cs#L206):

```
source-branches:
- develop
- release
```

We overrode that configuration, which I think, creates a bad reference:

```
source-branches:
- main
```

The `source-branches` list is a list of branch keys, not a list of branch names. In this case, we should revert the overridden configuration.

If this change works, we will need to update [all of these locations](https://github.com/search?q=org%3AOctopusDeploy+%22source-branches%3A+%5B%22main%22%5D%22&type=Code).

See https://octopusdeploy.slack.com/archives/C012VMX1YMQ/p1594091201478900

# How to review

🟢 Builds
Agree with the logic behind the change.
_shrug_