### PR TITLE
Better integration with our TeamCity build process

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -48,11 +48,11 @@ Task("__Default")
 Task("__CalculateVersion")
     .Does(() =>
 {
-    var fromEnvironment = EnvironmentVariable("GitVersion.NuGetVersion");
-    if (!string.IsNullOrWhiteSpace(fromEnvironment))
+    var fromArg = Argument("NuGetVersion", default(string));
+    if (!string.IsNullOrWhiteSpace(fromArg))
     {
-        nugetVersion = fromEnvironment;
-        Information($"Using GitVersion.NuGetVersion from environment variables: '{nugetVersion}'");
+        nugetVersion = fromArg;
+        Information($"Using GitVersion.NuGetVersion from build argument: '{nugetVersion}'");
     }
     else
     {

--- a/build.cake
+++ b/build.cake
@@ -32,9 +32,6 @@ var nugetVersion = gitVersionInfo.NuGetVersion;
 ///////////////////////////////////////////////////////////////////////////////
 Setup(context =>
 {
-    if(BuildSystem.IsRunningOnTeamCity)
-        BuildSystem.TeamCity.SetBuildNumber(gitVersionInfo.NuGetVersion);
-
     Information("Building " + packageName + " v{0}", nugetVersion);
 });
 


### PR DESCRIPTION
This is twofold:
1. Use the version calculated earlier or calculate it on the fly.
2. Don't push the version up to TeamCity in a service message.

# Use the version calculated earlier

We have a [GitVersion Meta Runner](https://build.octopushq.com/admin/editProject.html?projectId=_Root&tab=metaRunner&editRunnerId=GitVersion) we can use to calculate a reliable version and pass it down the stream to any future steps and build configurations. This reduces the risk of divergent version calculations across builds.

We were using this value for the three Octopus steps, but not for the actual build.

[Here](https://build.octopushq.com/buildConfiguration/OctopusDeploy_LIbraries_Data_Ci/1429093?buildTab=log&expandAll=true&focusLine=382) is an example of the new approach working.

# Calculate on the fly

This enables the local development experience. We want to build a version locally based on a commit, use that in other projects for local development, and eventually push everything to GitHub and build - but we really want the package reference to still work!

# Don't push the version up to TeamCity

This isn't the job of the cake script.

We also want to use FullSemVer for the build number since it is more informative, and use NuGetVersion when working with NuGet as a lowest common denominator.