### PR TITLE
Remove master from GitVersion.yml regex

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,4 +2,4 @@ mode: ContinuousDeployment
 
 branches:
   master:
-    regex: ^(main|master)$
+    regex: ^(main)$


### PR DESCRIPTION
We don't have a master branch any more, only `main`.

I like how this simplifies our GitVersion.yml configuration to the minimum required.

The build is working happily with `main` instead of `master`.

![image](https://user-images.githubusercontent.com/1627582/87000940-9b047700-c1f9-11ea-8453-e160a585755e.png)

# How to review?

Am I blind to any traps? My gut feel is if the build succeeds on this branch and on main, we are solid.