### PR TITLE
Sensitive Value Hints

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -53,14 +53,14 @@ Task("__CalculateVersion")
     if (!string.IsNullOrWhiteSpace(fromArg))
     {
         nugetVersion = fromArg;
-        Information($"Using GitVersion.NuGetVersion from build argument: '{nugetVersion}'");
+        Information($"Using GitVersion from build argument: '{nugetVersion}'");
     }
     else
     {
         var gitVersionInfo = GitVersion(new GitVersionSettings {
             OutputType = GitVersionOutput.Json
         });
-        nugetVersion = gitVersionInfo.NuGetVersion;
+        nugetVersion = gitVersionInfo.FullSemVer;
         Information($"Using calculated version: '{nugetVersion}'");
     }
 

--- a/source/Octopus.Data/Resources/SensitiveValue.cs
+++ b/source/Octopus.Data/Resources/SensitiveValue.cs
@@ -7,6 +7,7 @@ namespace Octopus.Data.Resources
     {
         public bool HasValue { get; set; }
         public string? NewValue { get; set; }
+        public string? Hint { get; set; }
 
         public bool Equals(SensitiveValue other)
         {

--- a/source/Octopus.Data/Resources/SensitiveValue.cs
+++ b/source/Octopus.Data/Resources/SensitiveValue.cs
@@ -3,18 +3,11 @@ using Octopus.Data.Model;
 
 namespace Octopus.Data.Resources
 {
-    public class SensitiveValue : IEquatable<SensitiveValue>
+    public class SensitiveValue
     {
         public bool HasValue { get; set; }
         public string? NewValue { get; set; }
         public string? Hint { get; set; }
-
-        public bool Equals(SensitiveValue other)
-        {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
-            return Equals(other.HasValue, HasValue) && Equals(other.NewValue, NewValue) && Equals(other.Hint, Hint);
-        }
 
         public static implicit operator SensitiveValue(string newValue)
         {

--- a/source/Octopus.Data/Resources/SensitiveValue.cs
+++ b/source/Octopus.Data/Resources/SensitiveValue.cs
@@ -13,7 +13,7 @@ namespace Octopus.Data.Resources
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Equals(other.HasValue, HasValue) && Equals(other.NewValue, NewValue);
+            return Equals(other.HasValue, HasValue) && Equals(other.NewValue, NewValue) && Equals(other.Hint, Hint);
         }
 
         public static implicit operator SensitiveValue(string newValue)


### PR DESCRIPTION
# Background

The Hint property is intended to allow sensitive values to indicate what their value is. For example, it might provide the first few characters of a authorization token.