### PR TITLE
Add GitHub workflow for approve/automerge PrettyBot PRs

### DIFF
--- a/.github/workflows/prettybot-pull-request-automation.yml
+++ b/.github/workflows/prettybot-pull-request-automation.yml
@@ -1,0 +1,28 @@
+name: "PrettyBot Pull Request Automation"
+
+on:
+  pull_request:
+    branches:    
+      - main
+
+# Increase the access for the GITHUB_TOKEN
+permissions:
+  # This Allows the GITHUB_TOKEN to approve pull requests
+  pull-requests: write
+  # This Allows the GITHUB_TOKEN to auto merge pull requests
+  contents: write
+
+env:
+  PR_URL: ${{github.event.pull_request.html_url}}
+  # By default, GitHub Actions workflows triggered by PrettyBot get a GITHUB_TOKEN with read-only permissions.
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+jobs:
+  prettybot:
+    runs-on: ubuntu-latest
+    if: ${{ (github.actor == 'Octobob') && (contains(github.head_ref, 'prettybot')) }}
+    steps:
+      - name: Approve a PrettyBot created PR
+        run: gh pr review --approve "$PR_URL"
+      - name: Enable auto-merge for PrettyBot PRs
+        run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
PrettyBot is an automatic process for running a code formatting tool across entire codebases. It's kicked off on a schedule via a TeamCity build.

#project-miso-change-control has introduced a PRGB requirement for all changes to our software.

Although we are upping our change control policies, we still want PRs created by bots to auto-merge on a green build.

This PR uses the guidance here to introduce a GitHub Action workflow that auto approves PrettyBot PRs when they are created.

This will ensure PRs raised by the bot will auto-merge on a green build.