### PR TITLE
Add Created field to IUser

### DIFF
--- a/source/Octopus.Data/Model/User/IUser.cs
+++ b/source/Octopus.Data/Model/User/IUser.cs
@@ -15,7 +15,7 @@ namespace Octopus.Data.Model.User
         bool IsService { get; set; }
         bool IsActive { get; set; }
         
-        DateTimeOffset Created { get; set; }
+        DateTimeOffset Created { get; protected set; }
 
         HashSet<Identity> Identities { get; }
 

--- a/source/Octopus.Data/Model/User/IUser.cs
+++ b/source/Octopus.Data/Model/User/IUser.cs
@@ -14,6 +14,8 @@ namespace Octopus.Data.Model.User
 
         bool IsService { get; set; }
         bool IsActive { get; set; }
+        
+        DateTimeOffset Created { get; set; }
 
         HashSet<Identity> Identities { get; }
 

--- a/source/Octopus.Data/Model/User/IUser.cs
+++ b/source/Octopus.Data/Model/User/IUser.cs
@@ -15,7 +15,7 @@ namespace Octopus.Data.Model.User
         bool IsService { get; set; }
         bool IsActive { get; set; }
         
-        DateTimeOffset Created { get; protected set; }
+        DateTimeOffset Created { get; }
 
         HashSet<Identity> Identities { get; }
 


### PR DESCRIPTION
[#team-user-onboarding](https://octopusdeploy.slack.com/archives/C02KJJD8D0X) is aiming to improve our tracking of activation rates in Amplitude. To achieve this, we're [adding](https://github.com/OctopusDeploy/OctopusDeploy/pull/12437) a `Created` field to the `UserResource`. 

I believe the OctopusDeploy PR linked above worked as-is just a few weeks ago, but now the server is returning `0001-01-01T00:00:00.000+00:00` instead of the value stored in the DB (e.g. `2022-07-13 08:55:47.4741710 +10:00`). 

In [GetCurrentUserRequestHandler.cs](https://github.com/OctopusDeploy/OctopusDeploy/blob/master/source/Octopus.Core/Features/Users/GetCurrentUserRequestHandler.cs#L33), the expected value is on `user`, but not on `mapped` (on line 40). 

In [MapFromUserToUserResource.cs](https://github.com/OctopusDeploy/OctopusDeploy/blob/master/source/Octopus.Server/Web/Mapping/Mappings/UserMappings/MapFromUserToUserResource.cs) there is no mention of the `Created` field, so I'm expecting it to work if I add `Created = source.Created,` at [line 64](https://github.com/OctopusDeploy/OctopusDeploy/blob/master/source/Octopus.Server/Web/Mapping/Mappings/UserMappings/MapFromUserToUserResource.cs#L64). However, the `source` there is of type `IUser`, which also has no knowledge of `Created`.

I'm hoping the change I've made here will have the intended effect, but have not been able to verify locally as I don't know how to build this project with an increased version number. Is someone able to provide instructions on how to do this?